### PR TITLE
Infra: adjust ESLint and Prettier config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "parserOptions": {
-    "ecmaVersion": 6,
+    "ecmaVersion": 2017,
     "sourceType": "module"
   },
   "rules": {}

--- a/.prettierrc
+++ b/.prettierrc
@@ -5,9 +5,7 @@
   "semi": true,
   "singleQuote": true,
   "quoteProps": "as-needed",
-  "trailingComma": "all",
   "bracketSpacing": true,
-  "jsxBracketSameLine": true,
   "arrowParens": "avoid",
   "endOfLine": "lf"
 }

--- a/src/app/javascript/control.js
+++ b/src/app/javascript/control.js
@@ -1,4 +1,4 @@
-Vue.component("play-control", {
+Vue.component('play-control', {
   template: `
         <div class="control">
         <a onclick="toggleControl()">Toggle Control</a> | <a onclick="startDemo1()">Demo 1</a> |

--- a/src/app/javascript/demo.js
+++ b/src/app/javascript/demo.js
@@ -2,9 +2,9 @@ let demoJson = `{"21p":{"timeline":[{"time":0.984595,"key":"k"},{"time":0.985222
 export const demo = JSON.parse(demoJson);
 
 window.startDemo1 = function startDemo1() {
-  window.startSong({ url: "songs/whywelose.mp3", noteName: "whywelose", visualizerNo: 3 });
+  window.startSong({ url: 'songs/whywelose.mp3', noteName: 'whywelose', visualizerNo: 3 });
 };
 
 window.startDemo2 = function startDemo2() {
-  window.startSong({ url: "songs/sheepdog.mp3", noteName: "sheepdog", visualizerNo: 2 });
+  window.startSong({ url: 'songs/sheepdog.mp3', noteName: 'sheepdog', visualizerNo: 2 });
 };

--- a/src/app/javascript/main.js
+++ b/src/app/javascript/main.js
@@ -1,20 +1,20 @@
-import { demo } from "./demo.js";
-import { DropTrack } from "./track.js";
-import { getPlayerTime, resetVideo, playVideo, loadYoutubeVideo } from "./youtube.js";
-require("./control.js");
+import { demo } from './demo.js';
+import { DropTrack } from './track.js';
+import { getPlayerTime, resetVideo, playVideo, loadYoutubeVideo } from './youtube.js';
+require('./control.js');
 
 //visualizers
 const visualizerArr = [
-  "Visualizer Off",
-  "Space Visualizer",
-  "Bar Visualizer",
-  "Space with Polygon",
-  "Space Blurred",
+  'Visualizer Off',
+  'Space Visualizer',
+  'Bar Visualizer',
+  'Space with Polygon',
+  'Space Blurred',
 ];
 
 //vue app
 let app = new Vue({
-  el: "#app",
+  el: '#app',
   data: {
     audio: null,
     canvas: null,
@@ -24,38 +24,38 @@ let app = new Vue({
     visualizerLoaded: false, //visualizer loaded indicator
     playMode: false, //play or edit mode
     noteSpeedInSec: 2,
-    currentSong: "",
-    loadFrom: "",
-    saveTo: "",
+    currentSong: '',
+    loadFrom: '',
+    saveTo: '',
     score: 0,
     combo: 0,
     maxCombo: 0,
     marks: { perfect: 0, good: 0, offbeat: 0, miss: 0 },
-    lastMark: "",
+    lastMark: '',
     demoList: Object.keys(demo),
-    currentDemoNotes: "",
+    currentDemoNotes: '',
     showControl: false,
     visualizer: 2,
     visualizerArr: visualizerArr,
-    srcMode: "youtube",
+    srcMode: 'youtube',
   },
   computed: {
-    mode: function() {
-      return this.playMode ? "Play Mode" : "Create Mode";
+    mode: function () {
+      return this.playMode ? 'Play Mode' : 'Create Mode';
     },
   },
-  mounted: function() {
-    this.$watch("currentSong", () => {
+  mounted: function () {
+    this.$watch('currentSong', () => {
       audio.load();
     });
-    this.$watch("noteSpeedInSec", () => {
+    this.$watch('noteSpeedInSec', () => {
       reposition();
     });
   },
 });
 
 app.canvas = app.$refs.mainCanvas;
-app.canvasCtx = app.canvas.getContext("2d");
+app.canvasCtx = app.canvas.getContext('2d');
 let canvas = app.canvas;
 let ctx = app.canvasCtx;
 canvas.width = window.innerWidth;
@@ -75,7 +75,7 @@ let audio = app.audio;
 let dropTrackArr = [];
 
 let trackNum = 4;
-let trackKeyBind = ["d", "f", "j", "k"];
+let trackKeyBind = ['d', 'f', 'j', 'k'];
 let trackMaxWidth = 150;
 
 function reposition() {
@@ -100,8 +100,8 @@ for (let keyBind of trackKeyBind) {
 
 reposition();
 
-window.addEventListener("resize", function(event) {
-  console.log("resize");
+window.addEventListener('resize', function (event) {
+  console.log('resize');
   reposition();
 });
 
@@ -117,24 +117,24 @@ function onKeyDown(key) {
   }
 }
 
-window.onload = function() {
+window.onload = function () {
   document.addEventListener(
-    "keydown",
-    (event) => {
+    'keydown',
+    event => {
       onKeyDown(event.key);
     },
     false
   );
 
   canvas.addEventListener(
-    "touchstart",
-    function(e) {
+    'touchstart',
+    function (e) {
       for (var c = 0; c < e.changedTouches.length; c++) {
         // touchInf[e.changedTouches[c].identifier] = {"x":e.changedTouches[c].clientX,"y":e.changedTouches[c].clientY};
         let x = e.changedTouches[c].clientX,
           y = e.changedTouches[c].clientY;
 
-        dropTrackArr.forEach(function(track) {
+        dropTrackArr.forEach(function (track) {
           if (x > track.x && x < track.x + track.width) {
             onKeyDown(track.keyBind);
           }
@@ -167,7 +167,7 @@ function renderVisualizer() {
       break;
     case 2:
       renderBarVisualizer();
-      ctx.fillStyle = "rgba(10,10,44,0.2)";
+      ctx.fillStyle = 'rgba(10,10,44,0.2)';
       ctx.fillRect(0, 0, canvas.width, canvas.height);
       break;
     case 3:
@@ -177,7 +177,7 @@ function renderVisualizer() {
       renderSpaceVisualizer(true);
       break;
     default:
-      ctx.fillStyle = "black";
+      ctx.fillStyle = 'black';
       ctx.fillRect(0, 0, canvas.width, canvas.height);
   }
 }
@@ -192,16 +192,16 @@ function playGame() {
   let startTime = Date.now();
   app.playMode = true;
 
-  let intervalPrePlay = setInterval(async function() {
+  let intervalPrePlay = setInterval(async function () {
     let elapsedTime = Date.now() - startTime;
     playTime = Number(elapsedTime / 1000);
     console.log(playTime, Number(app.noteSpeedInSec));
     if (playTime > Number(app.noteSpeedInSec)) {
       try {
-        if (app.srcMode == "url") {
+        if (app.srcMode == 'url') {
           res = await audio.play();
-          console.log("audio playing", res, audio.canplay);
-        } else if (app.srcMode == "youtube") {
+          console.log('audio playing', res, audio.canplay);
+        } else if (app.srcMode == 'youtube') {
           playVideo();
         }
       } catch (e) {
@@ -217,7 +217,7 @@ function playGame() {
 }
 
 function getCurrentTime() {
-  return app.srcMode == "youtube" ? getPlayerTime() : audio.currentTime;
+  return app.srcMode == 'youtube' ? getPlayerTime() : audio.currentTime;
 }
 
 function resetPlaying() {

--- a/src/app/javascript/note.js
+++ b/src/app/javascript/note.js
@@ -31,13 +31,13 @@ export function Note(x, width) {
     app.maxCombo = app.combo > app.maxCombo ? app.combo : app.maxCombo;
     if (percentage < 0.3) {
       app.marks.perfect += 1;
-      app.lastMark = "Perfect";
+      app.lastMark = 'Perfect';
     } else if (percentage < 0.6) {
       app.marks.good += 1;
-      app.lastMark = "Good";
+      app.lastMark = 'Good';
     } else if (percentage < 0.9) {
       app.marks.offbeat += 1;
-      app.lastMark = "Offbeat";
+      app.lastMark = 'Offbeat';
     }
     hitIndicator();
   };
@@ -47,7 +47,7 @@ export function Note(x, width) {
     if (app.playMode && isOut) {
       app.marks.miss += 1;
       app.combo = 0;
-      app.lastMark = "Miss";
+      app.lastMark = 'Miss';
       hitIndicator();
     }
     return isOut;
@@ -55,19 +55,19 @@ export function Note(x, width) {
 
   this.update = function () {
     this.setDelta();
-    let color = this.y > checkHitLineY + 10 ? "red" : "yellow";
+    let color = this.y > checkHitLineY + 10 ? 'red' : 'yellow';
     //Make note blur when get missed.
-    ctx.filter = this.y > checkHitLineY + 10 ? "blur(5px)" : "blur(0px)";
+    ctx.filter = this.y > checkHitLineY + 10 ? 'blur(5px)' : 'blur(0px)';
     ctx.fillStyle = color;
     ctx.fillRect(x, this.y, this.width, 10);
-    ctx.filter = "none";
+    ctx.filter = 'none';
     this.y += noteSpeedPxPerSec * this.delta;
   };
 }
 
 function hitIndicator() {
-  app.$refs.hitIndicator.classList.remove("hitAnimation");
+  app.$refs.hitIndicator.classList.remove('hitAnimation');
   setTimeout(() => {
-    app.$refs.hitIndicator.classList.add("hitAnimation");
+    app.$refs.hitIndicator.classList.add('hitAnimation');
   }, 1);
 }

--- a/src/app/javascript/storage.js
+++ b/src/app/javascript/storage.js
@@ -1,11 +1,11 @@
 export function saveToLocal(name) {
-  let local = JSON.parse(localStorage.getItem("localTimeline")) || {};
+  let local = JSON.parse(localStorage.getItem('localTimeline')) || {};
   local[name] = { timeline: timeArr };
-  localStorage.setItem("localTimeline", JSON.stringify(local));
+  localStorage.setItem('localTimeline', JSON.stringify(local));
 }
 
 export function loadFromLocal(name) {
-  let local = localStorage.getItem("localTimeline");
+  let local = localStorage.getItem('localTimeline');
   if (local) {
     local = JSON.parse(local);
     timeArr = local[name].timeline;

--- a/src/app/javascript/track.js
+++ b/src/app/javascript/track.js
@@ -39,7 +39,7 @@ export function DropTrack(x, width, keyBind, app) {
   this.update = function () {
     //track bg
     ctx.globalAlpha = 0.6;
-    ctx.fillStyle = "#212121";
+    ctx.fillStyle = '#212121';
     ctx.fillRect(this.x, 0, this.width, canvas.height);
     ctx.globalAlpha = 1;
 
@@ -53,7 +53,7 @@ export function DropTrack(x, width, keyBind, app) {
     }
     //hit indicator
     if (this.hitIndicatorOpacity > 0) {
-      ctx.fillStyle = "rgba(255,255,255," + this.hitIndicatorOpacity / 20 + ")";
+      ctx.fillStyle = 'rgba(255,255,255,' + this.hitIndicatorOpacity / 20 + ')';
       // let rectWidth = this.width * this.hitIndicatorOpacity;
       // ctx.fillRect(this.x + this.width / 2 - rectWidth / 2, 0, rectWidth, canvas.height);
       ctx.fillRect(this.x, 0, this.width, canvas.height);
@@ -66,7 +66,7 @@ export function DropTrack(x, width, keyBind, app) {
     }
 
     //hit line
-    ctx.fillStyle = "#ffffff";
+    ctx.fillStyle = '#ffffff';
     let hitLineY = app.playMode ? checkHitLineY : 0;
     ctx.fillRect(this.x, hitLineY, this.width, 10);
 
@@ -93,15 +93,15 @@ export function DropTrack(x, width, keyBind, app) {
 function getHitGradient(ctx, canvas) {
   //hit indicator gradient
   let hitGradient = ctx.createLinearGradient(0, (canvas.height / 10) * 7, 0, canvas.height);
-  hitGradient.addColorStop(0, "rgba(0,0,0,0)");
-  hitGradient.addColorStop(1, "yellow");
+  hitGradient.addColorStop(0, 'rgba(0,0,0,0)');
+  hitGradient.addColorStop(1, 'yellow');
   return hitGradient;
 }
 
 // ref https://css-tricks.com/adding-particle-effects-to-dom-elements-with-canvas/
 
 function HitParticleEffect() {
-  let colorData = ["yellow", "#DED51F", "#EBA400", "#FCC138"];
+  let colorData = ['yellow', '#DED51F', '#EBA400', '#FCC138'];
   let reductionFactor = 50;
 
   this.create = function (x, y, width, height) {
@@ -140,7 +140,7 @@ function HitParticleEffect() {
     this.remainingLife = this.life;
 
     // This function will be called by our animation logic later on
-    this.draw = (ctx) => {
+    this.draw = ctx => {
       let p = this;
 
       if (this.remainingLife > 0 && this.radius > 0) {

--- a/src/app/javascript/youtube.js
+++ b/src/app/javascript/youtube.js
@@ -1,9 +1,9 @@
 var ytPlayer;
 function onYouTubeIframeAPIReady() {
-  ytPlayer = new YT.Player("ytPlayer", {
-    height: "100%",
-    width: "100%",
-    videoId: "ALZHF5UqnU4",
+  ytPlayer = new YT.Player('ytPlayer', {
+    height: '100%',
+    width: '100%',
+    videoId: 'ALZHF5UqnU4',
     playerVars: { autoplay: 0, controls: 0, rel: 0 },
     events: {
       onReady: onPlayerReady,
@@ -15,7 +15,7 @@ function onYouTubeIframeAPIReady() {
 window.onYouTubeIframeAPIReady = onYouTubeIframeAPIReady;
 
 function onPlayerReady(event) {
-  console.log("Player Ready.");
+  console.log('Player Ready.');
   //   event.target.playVideo();
 }
 
@@ -38,7 +38,7 @@ export function getPlayerTime() {
 }
 
 function addWmode() {
-  let url = document.getElementById("ytPlayer").getAttribute("src");
-  let char = url.indexOf("?") != -1 ? "&" : "?";
-  document.getElementById("ytPlayer").setAttribute("src", url + char + "wmode=transparent");
+  let url = document.getElementById('ytPlayer').getAttribute('src');
+  let char = url.indexOf('?') != -1 ? '&' : '?';
+  document.getElementById('ytPlayer').setAttribute('src', url + char + 'wmode=transparent');
 }

--- a/src/app/visualizers/visualizerBar.js
+++ b/src/app/visualizers/visualizerBar.js
@@ -35,7 +35,7 @@ function renderBarVisualizer() {
 
   analyser.getByteFrequencyData(dataArray);
 
-  ctx.fillStyle = "#000";
+  ctx.fillStyle = '#000';
   ctx.fillRect(0, 0, WIDTH, HEIGHT);
 
   for (let i = 0; i < bufferLength; i++) {
@@ -50,7 +50,7 @@ function renderBarVisualizer() {
     if (barHeight != 0) {
       for (let j = 0; j <= barHeight; j += transValue) {
         temp += 1 / (barHeight / 50) / 2;
-        ctx.fillStyle = "rgba(" + r + "," + g + "," + b + "," + temp + ")";
+        ctx.fillStyle = 'rgba(' + r + ',' + g + ',' + b + ',' + temp + ')';
         ctx.fillRect(barX, HEIGHT - barHeight + j + 10, barWidth, barHeight / transValue);
       }
       barX += barWidth;

--- a/src/app/visualizers/visualizerSpace.js
+++ b/src/app/visualizers/visualizerSpace.js
@@ -4,7 +4,7 @@
  * original repo: https://github.com/michaelbromley/soundcloud-visualizer
  */
 
-let PlayerAudioSource = function(player) {
+let PlayerAudioSource = function (player) {
   let self = this;
   //   let analyser;
   //   let audioCtx = new (window.AudioContext || window.webkitAudioContext)();
@@ -15,7 +15,7 @@ let PlayerAudioSource = function(player) {
   // let source = src;
   // source.connect(analyser);
   // analyser.connect(audioCtx.destination);
-  let sampleAudioStream = function() {
+  let sampleAudioStream = function () {
     analyser.getByteFrequencyData(dataArray);
     // calculate an overall volume value
     let total = 0;
@@ -35,7 +35,7 @@ let PlayerAudioSource = function(player) {
  * which takes an options object specifying the element to append the canvases to and the audiosource which will
  * provide the data to be visualized.
  */
-let Visualizer = function() {
+let Visualizer = function () {
   let tileSize;
   let tiles = [];
   let stars = [];
@@ -74,7 +74,7 @@ let Visualizer = function() {
       this.vertices.push([x, y]);
     }
   }
-  Polygon.prototype.rotateVertices = function() {
+  Polygon.prototype.rotateVertices = function () {
     // rotate all the vertices to achieve the overall rotational effect
     let rotation = fgRotation;
     rotation -= getVolume() > 10000 ? Math.sin(getVolume() / 800000) : 0;
@@ -85,7 +85,7 @@ let Visualizer = function() {
   };
   let minMental = 0,
     maxMental = 0;
-  Polygon.prototype.calculateOffset = function(coords) {
+  Polygon.prototype.calculateOffset = function (coords) {
     let angle = Math.atan(coords[1] / coords[0]);
     let distance = Math.sqrt(Math.pow(coords[0], 2) + Math.pow(coords[1], 2)); // a bit of pythagoras
     let mentalFactor = Math.min(Math.max(Math.tan(getVolume() / 6000) * 0.5, -20), 2); // this factor makes the visualization go crazy wild
@@ -104,7 +104,7 @@ let Visualizer = function() {
     offsetY *= coords[0] < 0 ? -1 : 1;
     return [offsetX, offsetY];
   };
-  Polygon.prototype.drawPolygon = function() {
+  Polygon.prototype.drawPolygon = function () {
     let bucket = Math.ceil((dataArray.length / tiles.length) * this.num);
     let val = Math.pow(dataArray[bucket] / 255, 2) * 255;
     val *= this.num > 42 ? 1.1 : 1;
@@ -153,12 +153,12 @@ let Visualizer = function() {
       a = 0.5 / (1 + 40 * Math.pow(e, -val / 8)) + 0.5 / (1 + 40 * Math.pow(e, -val / 20));
 
       this.ctx.fillStyle =
-        "rgba(" + Math.round(r) + ", " + Math.round(g) + ", " + Math.round(b) + ", " + a + ")";
+        'rgba(' + Math.round(r) + ', ' + Math.round(g) + ', ' + Math.round(b) + ', ' + a + ')';
       this.ctx.fill();
       // stroke
       if (val > 20) {
         let strokeVal = 20;
-        this.ctx.strokeStyle = "rgba(" + strokeVal + ", " + strokeVal + ", " + strokeVal + ", 0.5)";
+        this.ctx.strokeStyle = 'rgba(' + strokeVal + ', ' + strokeVal + ', ' + strokeVal + ', 0.5)';
         this.ctx.lineWidth = 1;
         this.ctx.stroke();
       }
@@ -168,7 +168,7 @@ let Visualizer = function() {
          this.ctx.fillStyle = 'grey';
          this.ctx.fillText(this.num, this.vertices[0][0], this.vertices[0][1]);*/
   };
-  Polygon.prototype.drawHighlight = function() {
+  Polygon.prototype.drawHighlight = function () {
     this.ctx.beginPath();
     // draw the highlight
     let offset = this.calculateOffset(this.vertices[0]);
@@ -180,13 +180,13 @@ let Visualizer = function() {
     }
     this.ctx.closePath();
     let a = this.highlight / 100;
-    this.ctx.strokeStyle = "rgba(255, 255, 255, " + a + ")";
+    this.ctx.strokeStyle = 'rgba(255, 255, 255, ' + a + ')';
     this.ctx.lineWidth = 1;
     this.ctx.stroke();
     this.highlight -= 0.5;
   };
 
-  let makePolygonArray = function() {
+  let makePolygonArray = function () {
     tiles = [];
     /**
      * Arrange into a grid x, y, with the y axis at 60 degrees to the x, rather than
@@ -228,13 +228,13 @@ let Visualizer = function() {
     this.ctx = ctx;
     this.high = 0;
   }
-  Star.prototype.drawStar = function() {
+  Star.prototype.drawStar = function () {
     let distanceFromCentre = Math.sqrt(Math.pow(this.x, 2) + Math.pow(this.y, 2));
 
     // stars as lines
     let brightness = 200 + Math.min(Math.round(this.high * 5), 55);
     this.ctx.lineWidth = 0.5 + (distanceFromCentre / 2000) * Math.max(this.starSize / 2, 1);
-    this.ctx.strokeStyle = "rgba(" + brightness + ", " + brightness + ", " + brightness + ", 1)";
+    this.ctx.strokeStyle = 'rgba(' + brightness + ', ' + brightness + ', ' + brightness + ', 1)';
     this.ctx.beginPath();
     this.ctx.moveTo(this.x, this.y);
     let lengthFactor =
@@ -272,7 +272,7 @@ let Visualizer = function() {
     }
   };
 
-  let makeStarArray = function() {
+  let makeStarArray = function () {
     let x, y, starSize;
     stars = [];
     let limit = fgCanvas.width / 15; // how many stars?
@@ -284,7 +284,7 @@ let Visualizer = function() {
     }
   };
 
-  let drawBg = function() {
+  let drawBg = function () {
     bgCtx.clearRect(0, 0, bgCanvas.width, bgCanvas.height);
     let r, g, b, a;
     let val = getVolume() / 1000;
@@ -303,10 +303,10 @@ let Visualizer = function() {
       bgCanvas.height / 2,
       bgCanvas.width - Math.min(Math.pow(val, 2.7), bgCanvas.width - 20)
     );
-    grd.addColorStop(0, "rgba(0,0,0,0)"); // centre is transparent black
+    grd.addColorStop(0, 'rgba(0,0,0,0)'); // centre is transparent black
     grd.addColorStop(
       0.8,
-      "rgba(" + Math.round(r) + ", " + Math.round(g) + ", " + Math.round(b) + ", 0.4)"
+      'rgba(' + Math.round(r) + ', ' + Math.round(g) + ', ' + Math.round(b) + ', 0.4)'
     ); // edges are reddish
 
     bgCtx.fillStyle = grd;
@@ -322,7 +322,7 @@ let Visualizer = function() {
          bgCtx.fillText("a: " + a , 30, 150);*/
   };
 
-  this.resizeCanvas = function() {
+  this.resizeCanvas = function () {
     if (fgCanvas) {
       // resize the foreground canvas
       fgCanvas.width = window.innerWidth;
@@ -345,25 +345,25 @@ let Visualizer = function() {
     }
   };
 
-  let rotateForeground = function() {
-    tiles.forEach(function(tile) {
+  let rotateForeground = function () {
+    tiles.forEach(function (tile) {
       tile.rotateVertices();
     });
   };
 
-  let draw = function(drawPolygon) {
+  let draw = function (drawPolygon) {
     fgCtx.clearRect(-fgCanvas.width, -fgCanvas.height, fgCanvas.width * 2, fgCanvas.height * 2);
     sfCtx.clearRect(-fgCanvas.width / 2, -fgCanvas.height / 2, fgCanvas.width, fgCanvas.height);
 
-    stars.forEach(function(star) {
+    stars.forEach(function (star) {
       star.drawStar();
     });
     if (drawPolygon) {
-      tiles.forEach(function(tile) {
+      tiles.forEach(function (tile) {
         tile.drawPolygon();
       });
     }
-    tiles.forEach(function(tile) {
+    tiles.forEach(function (tile) {
       if (tile.highlight > 0) {
         tile.drawHighlight();
       }
@@ -377,26 +377,26 @@ let Visualizer = function() {
     // requestAnimationFrame(draw);
   };
 
-  this.init = function(options) {
+  this.init = function (options) {
     audioSource = options.audioSource;
     // let container = document.getElementById(options.containerId);
     let container = app.$refs.visualizerSpace;
 
     // foreground hexagons layer
-    fgCanvas = document.createElement("canvas");
-    fgCanvas.setAttribute("style", "position: absolute; z-index: 10");
-    fgCtx = fgCanvas.getContext("2d");
+    fgCanvas = document.createElement('canvas');
+    fgCanvas.setAttribute('style', 'position: absolute; z-index: 10');
+    fgCtx = fgCanvas.getContext('2d');
     container.appendChild(fgCanvas);
 
     // middle starfield layer
-    sfCanvas = document.createElement("canvas");
-    sfCtx = sfCanvas.getContext("2d");
-    sfCanvas.setAttribute("style", "position: absolute; z-index: 5");
+    sfCanvas = document.createElement('canvas');
+    sfCtx = sfCanvas.getContext('2d');
+    sfCanvas.setAttribute('style', 'position: absolute; z-index: 5');
     container.appendChild(sfCanvas);
 
     // background image layer
-    bgCanvas = document.createElement("canvas");
-    bgCtx = bgCanvas.getContext("2d");
+    bgCanvas = document.createElement('canvas');
+    bgCtx = bgCanvas.getContext('2d');
     container.appendChild(bgCanvas);
 
     makePolygonArray();
@@ -408,7 +408,7 @@ let Visualizer = function() {
     setInterval(drawBg, 100);
     setInterval(rotateForeground, 20);
     // resize the canvas to fill browser window dynamically
-    window.addEventListener("resize", this.resizeCanvas, false);
+    window.addEventListener('resize', this.resizeCanvas, false);
   };
 
   this.render = drawPolygon => {
@@ -425,8 +425,8 @@ function initSpaceVisualizer() {
   audioSource = new PlayerAudioSource();
 
   visualizer.init({
-    containerId: "visualizer",
-    audioSource: audioSource
+    containerId: 'visualizer',
+    audioSource: audioSource,
   });
 }
 


### PR DESCRIPTION
- Stop `prettier` from adding trailing commas to function arguments (valid since ES2017, see [Trailing Commas](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas).
    - ES2017 accepts trailing function arguments `function f(a, b, c,) {}`.
- Adjust `eslint` to accept ES2017 JavaScript syntax:
    - Accepts anonymous async function expressions like `async function () {}`.