### PR TITLE
Infra: Adjust eslint settings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,25 @@
 			}
 		}
 	},
+	"rules": {
+		"no-plusplus": 0,
+		"no-param-reassign": ["warn", { "props": false }],
+		"no-restricted-syntax": [
+			"error",
+			{ 
+				"selector": "ForInStatement",
+				"message": "for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array."
+			},
+			{
+				"selector": "LabeledStatement",
+				"message": "Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand."
+			},
+			{
+				"selector": "WithStatement",
+				"message": "`with` is disallowed in strict mode because it makes code impossible to predict and optimize."
+			}
+		]
+	},
 	"env": {
 		"es6": true,
 		"browser": true


### PR DESCRIPTION
- Turn off `no-plusplus` lint rule.
- Adjust `no-param-reassign` to only variable and not object properties.
- Remove `no-restricted-syntax` invocation for `ForOfStatement` (`for ... of`); the original reasoning from AirBnb's ESLint repo seems bad (see airbnb/javascript#1271).